### PR TITLE
feat: alphabet bar for touch-friendly letter filtering

### DIFF
--- a/app/components/AlphabetBar.tsx
+++ b/app/components/AlphabetBar.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+
+import type { Monster } from "../data/types";
+import { cn } from "../lib/utils";
+import { ACTIVE_CHIP_CLASS } from "./FilterBar";
+import { Button } from "./ui/button";
+
+const ALL_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+
+type AlphabetBarProps = {
+	monsters: Monster[];
+	activeLetter: string;
+	onLetterClick: (letter: string) => void;
+};
+
+export function AlphabetBar({
+	monsters,
+	activeLetter,
+	onLetterClick,
+}: AlphabetBarProps) {
+	const availableLetters = useMemo(
+		() => new Set(monsters.map((m) => m.name[0].toUpperCase())),
+		[monsters],
+	);
+
+	return (
+		<div className="flex flex-wrap gap-1">
+			{ALL_LETTERS.map((letter) => {
+				const available = availableLetters.has(letter);
+				const active = activeLetter.toUpperCase() === letter;
+				return (
+					<Button
+						key={letter}
+						variant="outline"
+						size="sm"
+						onClick={() => onLetterClick(letter)}
+						aria-pressed={active}
+						disabled={!available}
+						className={cn(
+							"min-h-[36px] min-w-[36px] rounded-lg border-border/80 font-mono text-sm transition-colors",
+							active && "font-semibold",
+							active && ACTIVE_CHIP_CLASS,
+							!available && "opacity-25",
+						)}
+					>
+						{letter}
+					</Button>
+				);
+			})}
+		</div>
+	);
+}

--- a/app/components/FilterBar.tsx
+++ b/app/components/FilterBar.tsx
@@ -9,6 +9,7 @@ import { Button } from "./ui/button";
 
 export const EMPTY_FILTERS: FilterState = {
 	search: "",
+	letterFilter: "",
 	defaultAttackTypes: [],
 	enragedAttackTypes: [],
 	elements: [],
@@ -19,6 +20,7 @@ export const EMPTY_FILTERS: FilterState = {
 function isFiltersEmpty(filters: FilterState): boolean {
 	return (
 		filters.search === "" &&
+		filters.letterFilter === "" &&
 		filters.defaultAttackTypes.length === 0 &&
 		filters.enragedAttackTypes.length === 0 &&
 		filters.elements.length === 0 &&
@@ -29,6 +31,7 @@ function isFiltersEmpty(filters: FilterState): boolean {
 
 function getActiveFilterCount(filters: FilterState): number {
 	return (
+		(filters.letterFilter ? 1 : 0) +
 		filters.defaultAttackTypes.length +
 		filters.enragedAttackTypes.length +
 		filters.elements.length +
@@ -50,7 +53,7 @@ const ELEMENT_ICONS: Record<Element, string> = {
 	[Element.NonElemental]: "⚪",
 };
 
-const ACTIVE_CHIP_CLASS =
+export const ACTIVE_CHIP_CLASS =
 	"border-primary bg-primary/15 text-foreground ring-2 ring-primary/30 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]";
 
 const ATTACK_TYPE_ACTIVE_CLASS: Record<AttackType, string> = {
@@ -70,6 +73,9 @@ const ATTACK_TYPE_LABELS: Record<AttackType, string> = {
 
 function getActiveFilterLabels(filters: FilterState): string[] {
 	return [
+		...(filters.letterFilter
+			? [`Letter: ${filters.letterFilter.toUpperCase()}`]
+			: []),
 		...filters.defaultAttackTypes.map(
 			(type) => `Default: ${ATTACK_TYPE_LABELS[type]}`,
 		),

--- a/app/data/filterMonsters.test.ts
+++ b/app/data/filterMonsters.test.ts
@@ -5,6 +5,7 @@ import { AttackType, Element } from "./types";
 
 const emptyFilters: FilterState = {
 	search: "",
+	letterFilter: "",
 	defaultAttackTypes: [],
 	enragedAttackTypes: [],
 	elements: [],
@@ -276,6 +277,7 @@ describe("filterMonsters", () => {
 		it("applies all five filter dimensions together", () => {
 			const result = filterMonsters(monsters, {
 				search: "Zinogre",
+				letterFilter: "",
 				defaultAttackTypes: [AttackType.Speed],
 				enragedAttackTypes: [AttackType.Technical],
 				elements: [Element.Thunder],
@@ -284,6 +286,61 @@ describe("filterMonsters", () => {
 			});
 			expect(result).toHaveLength(1);
 			expect(result[0].name).toBe("Zinogre");
+		});
+	});
+
+	describe("filter by letter", () => {
+		it("returns all monsters when letterFilter is empty string", () => {
+			const result = filterMonsters(monsters, {
+				...emptyFilters,
+				letterFilter: "",
+			});
+			expect(result).toHaveLength(monsters.length);
+		});
+
+		it("returns only monsters whose name starts with the given letter", () => {
+			const result = filterMonsters(monsters, {
+				...emptyFilters,
+				letterFilter: "A",
+			});
+			expect(result.length).toBeGreaterThan(0);
+			expect(result.every((m) => m.name.toUpperCase().startsWith("A"))).toBe(
+				true,
+			);
+		});
+
+		it("is case-insensitive", () => {
+			const upper = filterMonsters(monsters, {
+				...emptyFilters,
+				letterFilter: "A",
+			});
+			const lower = filterMonsters(monsters, {
+				...emptyFilters,
+				letterFilter: "a",
+			});
+			expect(lower).toEqual(upper);
+		});
+
+		it("returns empty array when no monster starts with that letter", () => {
+			const result = filterMonsters(monsters, {
+				...emptyFilters,
+				letterFilter: "Q",
+			});
+			expect(result).toHaveLength(0);
+		});
+
+		it("ANDs with other active filters", () => {
+			const result = filterMonsters(monsters, {
+				...emptyFilters,
+				letterFilter: "Z",
+				ranks: [5],
+			});
+			expect(result.length).toBeGreaterThan(0);
+			expect(
+				result.every(
+					(m) => m.name.toUpperCase().startsWith("Z") && m.rank === 5,
+				),
+			).toBe(true);
 		});
 	});
 

--- a/app/data/filterMonsters.ts
+++ b/app/data/filterMonsters.ts
@@ -2,6 +2,7 @@ import type { AttackType, Element, Monster } from "./types";
 
 export type FilterState = {
 	search: string;
+	letterFilter: string;
 	defaultAttackTypes: AttackType[];
 	enragedAttackTypes: AttackType[];
 	elements: Element[];
@@ -15,6 +16,7 @@ export function filterMonsters(
 ): Monster[] {
 	const {
 		search,
+		letterFilter,
 		defaultAttackTypes,
 		enragedAttackTypes,
 		elements,
@@ -23,9 +25,11 @@ export function filterMonsters(
 	} = filters;
 
 	const query = search.trim().toLowerCase();
+	const letter = letterFilter.toUpperCase();
 
 	const result = monsters.filter((m) => {
 		if (query && !m.name.toLowerCase().includes(query)) return false;
+		if (letter && !m.name.toUpperCase().startsWith(letter)) return false;
 		if (
 			defaultAttackTypes.length > 0 &&
 			!defaultAttackTypes.includes(m.defaultAttackType)

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { AlphabetBar } from "../components/AlphabetBar";
 import { EMPTY_FILTERS, FilterBar } from "../components/FilterBar";
 import { MonsterCard } from "../components/MonsterCard";
 import { filterMonsters } from "../data/filterMonsters";
@@ -61,12 +62,26 @@ export default function Home() {
 					</div>
 				</header>
 
-				<div className="mb-6">
+				<div className="mb-4">
 					<FilterBar
 						filters={filters}
 						onChange={setFilters}
 						resultCount={filteredMonsters.length}
 						totalCount={monsters.length}
+					/>
+				</div>
+
+				<div className="mb-6">
+					<AlphabetBar
+						monsters={monsters}
+						activeLetter={filters.letterFilter}
+						onLetterClick={(letter) =>
+							setFilters({
+								...filters,
+								letterFilter:
+									filters.letterFilter.toUpperCase() === letter ? "" : letter,
+							})
+						}
 					/>
 				</div>
 


### PR DESCRIPTION
## Summary

- Adds an A–Z alphabet button bar between the FilterBar and monster grid
- Tapping a letter filters to monsters starting with that letter; tap again to deselect
- Letters with no monsters (Q, U, W, X) are dimmed and non-interactive
- Letter filter stacks with all existing filters (AND logic) and is cleared by the "Clear filters" button
- Active letter shown as a chip in the filter summary row

## Test plan

- [ ] `pnpm test` — all 34 tests pass (5 new tests cover `letterFilter` in `filterMonsters`)
- [ ] `pnpm typecheck && pnpm lint` — no errors
- [ ] Tap a letter → grid filters to matching monsters, letter highlights
- [ ] Tap the same letter again → filter clears
- [ ] Activate another filter (e.g. Power attack) then tap a letter → both filters apply
- [ ] Press "Clear filters" → letter filter and all other filters reset
- [ ] Tap Q/U/W/X → buttons are dimmed and non-interactive